### PR TITLE
Nerf first day and playoffs triple-or-nothing

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -43,7 +43,7 @@ Side Quests:
 
 3.  **MVPs.** Once a territory has been assigned to an owner, a player on that territory who played for the winning team shall be selected to serve as the MVP for that team and territory pair. That player shall have their MVP count incremented by one. In the case that no players were placed on a territory, no MVPs will be assigned (e.g. a territory and its surrounding territories all owned by the same team prior to the roll).
     
-4.  **Triple or Nothing.** If a team controls only one territory, each player on that team may elect to triple-or-nothing their power if they are defending that territory. If that player is attacking or elects not to triple-or-nothing their power, then the multiplier will not be affected.
+4.  **Triple or Nothing.** If a team controls only one territory and it's neithe first day nor the playoffs, each player on that team may elect to triple-or-nothing their power if they are defending that territory. If that player is attacking or elects not to triple-or-nothing their power, then the multiplier will not be affected.
     
 5.  **Region Multipliers.** A team who owns a whole region will get a 2x multiplier for each region. These multipliers shall be cumulative (2, 4, 6).
     

--- a/proposals/0001-no-first-day-triple.md
+++ b/proposals/0001-no-first-day-triple.md
@@ -1,0 +1,10 @@
+# Proposal Title: (No Triple-or-Nothing on Regular Season Day 1 or During Playoffs)
+Author: Mautamu
+Co-Author: 
+Cosigners: 
+Request: Change Rust Risk to allow users to signin using Reddit
+Linked Pull Request:
+
+## Rationale
+Removing the day 1 triple-or-nothing will encourage teams to attack. Removing it during playoffs will prevent a team from winning simply on triple-or-nothing alone. 
+


### PR DESCRIPTION
# Proposal Title: (No Triple-or-Nothing on Regular Season Day 1 or During Playoffs)
Author: Mautamu
Co-Author:
Cosigners:
Request: Change Rust Risk to allow users to signin using Reddit
Linked Pull Request:

## Rationale
Removing the day 1 triple-or-nothing will encourage teams to attack. Removing it during playoffs will prevent a team from winning simply on triple-or-nothing alone.