### PR TITLE
Merge 0004-map-and-regions.md (#5) into main.

### DIFF
--- a/proposals/0004-map-and-regions.md
+++ b/proposals/0004-map-and-regions.md
@@ -4,7 +4,8 @@ Author: Westopher
 Cosigners: littlemojo, GoCardinal07, Mangojuulpods, jaket 
 
 Request: Add Minnesota and Wisconsin to the Northeast Canada Region. Add Bridges between Hawaii and Guerrero. Add Bridges between Nova Scotia and North Carolina. Add bridge between New Orleans and Yucatan. Remove Hawaii to Puerto Rico Bridge. Change Annaplois bridge to Puerto Rico. 
-Linked Pull Request: N/A. 
+
+Linked Pull Request: https://github.com/CollegeFootballRisk/Risk/pull/60
 
 ## Rationale
 

--- a/proposals/0004-map-and-regions.md
+++ b/proposals/0004-map-and-regions.md
@@ -1,5 +1,6 @@
 # Proposal Title: (Bridge and East Canada Region Tweaks)
 Author: Westopher
+
 Cosigners: littlemojo, GoCardinal07, Mangojuulpods, jaket 
 
 Request: Add Minnesota and Wisconsin to the Northeast Canada Region. Add Bridges between Hawaii and Guerrero. Add Bridges between Nova Scotia and North Carolina. Add bridge between New Orleans and Yucatan. Remove Hawaii to Puerto Rico Bridge. Change Annaplois bridge to Puerto Rico. 


### PR DESCRIPTION
# Proposal Title: (Bridge and East Canada Region Tweaks)
Author: Westopher

Cosigners: littlemojo, GoCardinal07, Mangojuulpods, jaket 

Request: Add Minnesota and Wisconsin to the Northeast Canada Region. Add Bridges between Hawaii and Guerrero. Add Bridges between Nova Scotia and North Carolina. Add bridge between New Orleans and Yucatan. Remove Hawaii to Puerto Rico Bridge. Change Annaplois bridge to Puerto Rico. 
Linked Pull Request: N/A. 

## Rationale

This serves two purposes:
1. It adds 11 territories to the Northeast Canada region, which previously had only 9, the lowest in the game, despite also being one of the easiest regions to acquire and hold. 
2. This change adds and tweaks several bridges throughout the map to add strategic balance, increase mobility in a rational way, and limit near-unbreakable safe zones in future games. Most of the bridges intentionally go from a highly-contested area to a corner of the map, and not from corner to corner. Also allows for more equal access to colonizeable territories at the start of the game, if that idea is implemented in further games.

 ![alt text](https://media.discordapp.net/attachments/746178179844145154/934219389035753482/unknown-7.png?width=721&height=613)
 ![alt text](https://media.discordapp.net/attachments/746178179844145154/934219429875707934/risk_ideal_bridge_map.png?width=532&height=613)